### PR TITLE
DHCP6 subnet preferred_lifetime should be an Integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of isc_kea.
 
 ## Unreleased
 
+- DHCP6 subnet preferred_lifetime should be an Integer
+
 ## 1.0.0 - *2023-06-24*
 
 - Fix CI pipeline

--- a/documentation/partial/isc_kea__config_dhcp6_parameters_subnet.md
+++ b/documentation/partial/isc_kea__config_dhcp6_parameters_subnet.md
@@ -29,7 +29,7 @@
 | `min_valid_lifetime`           |       | Integer        |         |             |                                               |
 | `max_preferred_lifetime`       |       | Integer        |         |             |                                               |
 | `max_valid_lifetime`           |       | Integer        |         |             |                                               |
-| `preferred_lifetime`           |       | String         |         |             |                                               |
+| `preferred_lifetime`           |       | Integer        |         |             |                                               |
 | `rapid_commit`                 |       | true, false    |         |             |                                               |
 | `rebind_timer`                 |       | Integer        |         |             |                                               |
 | `relay`                        |       | Hash           |         |             |                                               |

--- a/resources/partial/_config_dhcp6_parameters_subnet.rb
+++ b/resources/partial/_config_dhcp6_parameters_subnet.rb
@@ -57,7 +57,7 @@ property :max_preferred_lifetime, Integer
 
 property :max_valid_lifetime, Integer
 
-property :preferred_lifetime, String
+property :preferred_lifetime, Integer
 
 property :rapid_commit, [true, false]
 


### PR DESCRIPTION
# Description

- DHCP6 subnet preferred_lifetime should be an Integer

## Issues Resolved

- n/a

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
