### PR TITLE
Kea 2.4 Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,9 @@ jobs:
           - 'centos-stream-9'
           - 'rockylinux-8'
           - 'rockylinux-9'
-          - 'fedora-36'
+          - 'fedora-38'
           - 'debian-11'
+          - 'debian-12'
           - 'ubuntu-2004'
           - 'ubuntu-2204'
         suite:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This file is used to list changes made in each version of isc_kea.
 
 ## Unreleased
 
+- Update installation packages to cover versions greater than 2.2
+- Kitchen test with Kea 2.4
+- Updates for Kea 2.4 release
+  - Add `allocator` property to `config_dhcp4`
+  - Add `allocator` and `pd_allocator` property to `config_dhcp6`
+  - Add `template_test` property to `config_dhcp4_client_class` and `config_dhcp6_client_class`
+
 ## 1.0.2 - *2023-07-12*
 
 ## 1.0.1 - *2023-07-03*

--- a/libraries/install.rb
+++ b/libraries/install.rb
@@ -52,6 +52,8 @@ module IscKea
           'https://dl.cloudsmith.io/public/isc/kea-2-2/gpg.A8CB727C62565FF8.key'
         when '2-3'
           'https://dl.cloudsmith.io/public/isc/kea-2-3/gpg.DA05D46B7BABA24A.key'
+        when '2-4'
+          'https://dl.cloudsmith.io/public/isc/kea-2-4/gpg.0D9D9A1439E23DB9.key'
         else
           raise ArgumentError, "Unsupported version #{install_version}"
         end
@@ -60,18 +62,16 @@ module IscKea
       def default_kea_install_packages
         case node['platform_family']
         when 'amazon', 'fedora', 'rhel'
-          case install_version.gsub('-', '.').to_f
-          when 2.3
-            %w(isc-kea isc-kea-admin isc-kea-common isc-kea-ctrl-agent isc-kea-devel isc-kea-dhcp-ddns isc-kea-dhcp4 isc-kea-dhcp6 isc-kea-doc isc-kea-hooks isc-kea-perfdhcp)
-          else
+          if install_version.gsub('-', '.').to_f <= 2.2
             %w(isc-kea isc-kea-devel isc-kea-hooks isc-kea-libs isc-kea-shell)
+          else
+            %w(isc-kea isc-kea-admin isc-kea-common isc-kea-ctrl-agent isc-kea-devel isc-kea-dhcp-ddns isc-kea-dhcp4 isc-kea-dhcp6 isc-kea-doc isc-kea-hooks isc-kea-perfdhcp)
           end
         when 'debian'
-          case install_version.gsub('-', '.').to_f
-          when 2.3
-            %w(isc-kea isc-kea-dev isc-kea-perfdhcp)
-          else
+          if install_version.gsub('-', '.').to_f <= 2.2
             %w(isc-kea-admin isc-kea-common isc-kea-ctrl-agent isc-kea-dev isc-kea-dhcp-ddns-server isc-kea-dhcp4-server isc-kea-dhcp6-server isc-kea-doc)
+          else
+            %w(isc-kea isc-kea-dev isc-kea-perfdhcp)
           end
         else
           raise ArgumentError, "Unsupported platform family #{node['platform_family']}"

--- a/resources/config_dhcp4.rb
+++ b/resources/config_dhcp4.rb
@@ -26,6 +26,9 @@ def auto_accumulator_options_override
   { config_path_override: %w(Dhcp4) }.freeze
 end
 
+property :allocator, String,
+          equal_to: %w(iterative random flq)
+
 property :authoritative, [true, false]
 
 property :boot_file_name, String

--- a/resources/config_dhcp4_client_class.rb
+++ b/resources/config_dhcp4_client_class.rb
@@ -40,6 +40,8 @@ property :class_name, String,
 
 property :test, String
 
+property :template_test, String
+
 property :option_def, [Array, Hash],
           coerce: proc { |p| p.is_a?(Array) ? p.deep_sort : [p.deep_sort] }
 

--- a/resources/config_dhcp6.rb
+++ b/resources/config_dhcp6.rb
@@ -26,6 +26,9 @@ def auto_accumulator_options_override
   { config_path_override: %w(Dhcp6) }.freeze
 end
 
+property :allocator, String,
+          equal_to: %w(iterative random)
+
 property :cache_threshold, Integer
 
 property :cache_max_age, Integer
@@ -76,6 +79,9 @@ property :max_preferred_lifetime, Integer
 property :max_valid_lifetime, Integer
 
 property :parked_packet_limit, Integer
+
+property :pd_allocator, String,
+          equal_to: %w(iterative random flq)
 
 property :preferred_lifetime, Integer
 

--- a/resources/config_dhcp6_client_class.rb
+++ b/resources/config_dhcp6_client_class.rb
@@ -40,6 +40,8 @@ property :class_name, String,
 
 property :test, String
 
+property :template_test, String
+
 property :option_def, [Array, Hash],
           coerce: proc { |p| p.is_a?(Array) ? p.deep_sort : [p.deep_sort] }
 

--- a/resources/partial/_config_dhcp4_parameters_subnet.rb
+++ b/resources/partial/_config_dhcp4_parameters_subnet.rb
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+property :allocator, String,
+          equal_to: %w(iterative random flq)
+
 property :subnet_4o6_interface, String
 
 property :subnet_4o6_interface_id, String

--- a/resources/partial/_config_dhcp6_parameters_subnet.rb
+++ b/resources/partial/_config_dhcp6_parameters_subnet.rb
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+property :allocator, String,
+          equal_to: %w(iterative random)
+
 property :cache_threshold, [Integer, Float]
 
 property :cache_max_age, [Integer, Float]
@@ -56,6 +59,9 @@ property :min_valid_lifetime, Integer
 property :max_preferred_lifetime, Integer
 
 property :max_valid_lifetime, Integer
+
+property :pd_allocator, String,
+          equal_to: %w(iterative random flq)
 
 property :preferred_lifetime, Integer
 

--- a/test/cookbooks/isc_kea_test/recipes/install.rb
+++ b/test/cookbooks/isc_kea_test/recipes/install.rb
@@ -18,6 +18,6 @@
 #
 
 isc_kea_install 'kea' do
-  install_version '2.3'
+  install_version '2.4'
   action :install
 end


### PR DESCRIPTION
# Description

- Update installation packages to cover versions greater than 2.2
- Kitchen test with Kea 2.4
- Updates for Kea 2.4 release
  - Add `allocator` property to `config_dhcp4`
  - Add `allocator` and `pd_allocator` property to `config_dhcp6`
  - Add `template_test` property to `config_dhcp4_client_class` and `config_dhcp6_client_class`

## Issues Resolved

- n/a

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
