### PR TITLE
Add `ddns-ttl-percent` option to all places it can be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of isc_kea.
 
 ## Unreleased
 
+- Add `ddns-ttl-percent` option to all places it can be used
+
 ## 1.1.0 - *2023-07-12*
 
 - Update installation packages to cover versions greater than 2.2

--- a/documentation/isc_kea_config_dhcp6.md
+++ b/documentation/isc_kea_config_dhcp6.md
@@ -13,44 +13,45 @@
 
 ## Properties
 
-| Name                             | Name? | Type           | Default | Description | Allowed Values                                |
-| -------------------------------- | ----- | -------------- | ------- | ----------- | --------------------------------------------- |
-| `cache_threshold`                |       | Integer        |         |             |                                               |
-| `cache_max_age`                  |       | Integer        |         |             |                                               |
-| `calculate_tee_times`            |       | true, false    |         |             |                                               |
-| `data_directory`                 |       | String         |         |             |                                               |
-| `ddns_generated_prefix`          |       | String         |         |             |                                               |
-| `ddns_override_client_update`    |       | true, false    |         |             |                                               |
-| `ddns_override_no_update`        |       | true, false    |         |             |                                               |
-| `ddns_replace_client_name`       |       | String, Symbol |         |             | never, always, when-present, when-not-present |
-| `ddns_qualifying_suffix`         |       | String         |         |             |                                               |
-| `ddns_send_updates`              |       | true, false    |         |             |                                               |
-| `ddns_update_on_renew`           |       | true, false    |         |             |                                               |
-| `ddns_use_conflict_resolution`   |       | true, false    |         |             |                                               |
-| `decline_probation_period`       |       | Integer        |         |             |                                               |
-| `dhcp4o6_port`                   |       | Integer        |         |             |                                               |
-| `host_reservation_identifiers`   |       | Array          |         |             |                                               |
-| `hostname_char_replacement`      |       | String         |         |             |                                               |
-| `hostname_char_set`              |       | String         |         |             |                                               |
-| `ip_reservations_unique`         |       | true, false    |         |             |                                               |
-| `mac_sources`                    |       | String, Array  |         |             |                                               |
-| `min_preferred_lifetime`         |       | Integer        |         |             |                                               |
-| `min_valid_lifetime`             |       | Integer        |         |             |                                               |
-| `max_preferred_lifetime`         |       | Integer        |         |             |                                               |
-| `max_valid_lifetime`             |       | Integer        |         |             |                                               |
-| `parked_packet_limit`            |       | Integer        |         |             |                                               |
-| `preferred_lifetime`             |       | Integer        |         |             |                                               |
-| `rapid_commit`                   |       | String         |         |             |                                               |
-| `rebind_timer`                   |       | Integer        |         |             |                                               |
-| `relay_supplied_options`         |       | String, Array  |         |             |                                               |
-| `renew_timer`                    |       | Integer        |         |             |                                               |
-| `reservations_global`            |       | true, false    |         |             |                                               |
-| `reservations_in_subnet`         |       | true, false    |         |             |                                               |
-| `reservations_out_of_pool`       |       | true, false    |         |             |                                               |
-| `server_tag`                     |       | String         |         |             |                                               |
-| `statistic_default_sample_count` |       | Integer        |         |             |                                               |
-| `statistic_default_sample_age`   |       | Integer        |         |             |                                               |
-| `store_extended_info`            |       | true, false    |         |             |                                               |
-| `t1_percent`                     |       | Integer, Float |         |             |                                               |
-| `t2_percent`                     |       | Integer, Float |         |             |                                               |
-| `valid_lifetime`                 |       | Integer        |         |             |                                               |
+| Name                             | Name? | Type                   | Default | Description | Allowed Values                                |
+| -------------------------------- | ----- | ---------------------- | ------- | ----------- | --------------------------------------------- |
+| `cache_threshold`                |       | Integer                |         |             |                                               |
+| `cache_max_age`                  |       | Integer                |         |             |                                               |
+| `calculate_tee_times`            |       | true, false            |         |             |                                               |
+| `data_directory`                 |       | String                 |         |             |                                               |
+| `ddns_generated_prefix`          |       | String                 |         |             |                                               |
+| `ddns_override_client_update`    |       | true, false            |         |             |                                               |
+| `ddns_override_no_update`        |       | true, false            |         |             |                                               |
+| `ddns_replace_client_name`       |       | String, Symbol         |         |             | never, always, when-present, when-not-present |
+| `ddns_qualifying_suffix`         |       | String                 |         |             |                                               |
+| `ddns_send_updates`              |       | true, false            |         |             |                                               |
+| `ddns_ttl_percent`               |       | Float, Integer, String |         |             |                                               |
+| `ddns_update_on_renew`           |       | true, false            |         |             |                                               |
+| `ddns_use_conflict_resolution`   |       | true, false            |         |             |                                               |
+| `decline_probation_period`       |       | Integer                |         |             |                                               |
+| `dhcp4o6_port`                   |       | Integer                |         |             |                                               |
+| `host_reservation_identifiers`   |       | Array                  |         |             |                                               |
+| `hostname_char_replacement`      |       | String                 |         |             |                                               |
+| `hostname_char_set`              |       | String                 |         |             |                                               |
+| `ip_reservations_unique`         |       | true, false            |         |             |                                               |
+| `mac_sources`                    |       | String, Array          |         |             |                                               |
+| `min_preferred_lifetime`         |       | Integer                |         |             |                                               |
+| `min_valid_lifetime`             |       | Integer                |         |             |                                               |
+| `max_preferred_lifetime`         |       | Integer                |         |             |                                               |
+| `max_valid_lifetime`             |       | Integer                |         |             |                                               |
+| `parked_packet_limit`            |       | Integer                |         |             |                                               |
+| `preferred_lifetime`             |       | Integer                |         |             |                                               |
+| `rapid_commit`                   |       | String                 |         |             |                                               |
+| `rebind_timer`                   |       | Integer                |         |             |                                               |
+| `relay_supplied_options`         |       | String, Array          |         |             |                                               |
+| `renew_timer`                    |       | Integer                |         |             |                                               |
+| `reservations_global`            |       | true, false            |         |             |                                               |
+| `reservations_in_subnet`         |       | true, false            |         |             |                                               |
+| `reservations_out_of_pool`       |       | true, false            |         |             |                                               |
+| `server_tag`                     |       | String                 |         |             |                                               |
+| `statistic_default_sample_count` |       | Integer                |         |             |                                               |
+| `statistic_default_sample_age`   |       | Integer                |         |             |                                               |
+| `store_extended_info`            |       | true, false            |         |             |                                               |
+| `t1_percent`                     |       | Integer, Float         |         |             |                                               |
+| `t2_percent`                     |       | Integer, Float         |         |             |                                               |
+| `valid_lifetime`                 |       | Integer                |         |             |                                               |

--- a/documentation/partial/isc_kea__config_dhcp4_parameters_shared_network.md
+++ b/documentation/partial/isc_kea__config_dhcp4_parameters_shared_network.md
@@ -8,43 +8,44 @@
 
 ## Properties
 
-| Name                           | Name? | Type           | Default | Description | Allowed Values                                |
-| ------------------------------ | ----- | -------------- | ------- | ----------- | --------------------------------------------- |
-| `authoritative`                |       | true, false    |         |             |                                               |
-| `boot_file_name`               |       | String         |         |             |                                               |
-| `cache_threshold`              |       | Integer        |         |             |                                               |
-| `cache_max_age`                |       | Integer        |         |             |                                               |
-| `calculate_tee_times`          |       | true, false    |         |             |                                               |
-| `client_class`                 |       | String         |         |             |                                               |
-| `ddns_generated_prefix`        |       | String         |         |             |                                               |
-| `ddns_override_client_update`  |       | true, false    |         |             |                                               |
-| `ddns_override_no_update`      |       | true, false    |         |             |                                               |
-| `ddns_replace_client_name`     |       | String, Symbol |         |             | never, always, when-present, when-not-present |
-| `ddns_qualifying_suffix`       |       | String         |         |             |                                               |
-| `ddns_send_updates`            |       | true, false    |         |             |                                               |
-| `ddns_update_on_renew`         |       | true, false    |         |             |                                               |
-| `ddns_use_conflict_resolution` |       | true, false    |         |             |                                               |
-| `hostname_char_set`            |       | String         |         |             |                                               |
-| `hostname_char_replacement`    |       | String         |         |             |                                               |
-| `interface`                    |       | String         |         |             |                                               |
-| `match_client_id`              |       | true, false    |         |             |                                               |
-| `min_valid_lifetime`           |       | Integer        |         |             |                                               |
-| `max_valid_lifetime`           |       | Integer        |         |             |                                               |
-| `next_server`                  |       | String         |         |             |                                               |
-| `option_data`                  |       | Array          |         |             |                                               |
-| `rebind_timer`                 |       | Integer        |         |             |                                               |
-| `relay`                        |       | Hash           |         |             |                                               |
-| `renew_timer`                  |       | Integer        |         |             |                                               |
-| `reservations_global`          |       | true, false    |         |             |                                               |
-| `reservations_in_subnet`       |       | true, false    |         |             |                                               |
-| `reservations_out_of_pool`     |       | true, false    |         |             |                                               |
-| `require_client_classes`       |       | Array          |         |             |                                               |
-| `server_hostname`              |       | String         |         |             |                                               |
-| `valid_lifetime`               |       | String         |         |             |                                               |
-| `relay`                        |       | String         |         |             |                                               |
-| `require_client_classes`       |       | String         |         |             |                                               |
-| `server_hostname`              |       | String         |         |             |                                               |
-| `store_extended_info`          |       | true, false    |         |             |                                               |
-| `t1_percent`                   |       | Integer, Float |         |             |                                               |
-| `t2_percent`                   |       | Integer, Float |         |             |                                               |
-| `valid_lifetime`               |       | Integer        |         |             |                                               |
+| Name                           | Name? | Type                   | Default | Description | Allowed Values                                |
+| ------------------------------ | ----- | ---------------------- | ------- | ----------- | --------------------------------------------- |
+| `authoritative`                |       | true, false            |         |             |                                               |
+| `boot_file_name`               |       | String                 |         |             |                                               |
+| `cache_threshold`              |       | Integer                |         |             |                                               |
+| `cache_max_age`                |       | Integer                |         |             |                                               |
+| `calculate_tee_times`          |       | true, false            |         |             |                                               |
+| `client_class`                 |       | String                 |         |             |                                               |
+| `ddns_generated_prefix`        |       | String                 |         |             |                                               |
+| `ddns_override_client_update`  |       | true, false            |         |             |                                               |
+| `ddns_override_no_update`      |       | true, false            |         |             |                                               |
+| `ddns_replace_client_name`     |       | String, Symbol         |         |             | never, always, when-present, when-not-present |
+| `ddns_qualifying_suffix`       |       | String                 |         |             |                                               |
+| `ddns_send_updates`            |       | true, false            |         |             |                                               |
+| `ddns_ttl_percent`             |       | Float, Integer, String |         |             |                                               |
+| `ddns_update_on_renew`         |       | true, false            |         |             |                                               |
+| `ddns_use_conflict_resolution` |       | true, false            |         |             |                                               |
+| `hostname_char_set`            |       | String                 |         |             |                                               |
+| `hostname_char_replacement`    |       | String                 |         |             |                                               |
+| `interface`                    |       | String                 |         |             |                                               |
+| `match_client_id`              |       | true, false            |         |             |                                               |
+| `min_valid_lifetime`           |       | Integer                |         |             |                                               |
+| `max_valid_lifetime`           |       | Integer                |         |             |                                               |
+| `next_server`                  |       | String                 |         |             |                                               |
+| `option_data`                  |       | Array                  |         |             |                                               |
+| `rebind_timer`                 |       | Integer                |         |             |                                               |
+| `relay`                        |       | Hash                   |         |             |                                               |
+| `renew_timer`                  |       | Integer                |         |             |                                               |
+| `reservations_global`          |       | true, false            |         |             |                                               |
+| `reservations_in_subnet`       |       | true, false            |         |             |                                               |
+| `reservations_out_of_pool`     |       | true, false            |         |             |                                               |
+| `require_client_classes`       |       | Array                  |         |             |                                               |
+| `server_hostname`              |       | String                 |         |             |                                               |
+| `valid_lifetime`               |       | String                 |         |             |                                               |
+| `relay`                        |       | String                 |         |             |                                               |
+| `require_client_classes`       |       | String                 |         |             |                                               |
+| `server_hostname`              |       | String                 |         |             |                                               |
+| `store_extended_info`          |       | true, false            |         |             |                                               |
+| `t1_percent`                   |       | Integer, Float         |         |             |                                               |
+| `t2_percent`                   |       | Integer, Float         |         |             |                                               |
+| `valid_lifetime`               |       | Integer                |         |             |                                               |

--- a/documentation/partial/isc_kea__config_dhcp4_parameters_subnet.md
+++ b/documentation/partial/isc_kea__config_dhcp4_parameters_subnet.md
@@ -8,44 +8,45 @@
 
 ## Properties
 
-| Name                           | Name? | Type           | Default | Description | Allowed Values                                |
-| ------------------------------ | ----- | -------------- | ------- | ----------- | --------------------------------------------- |
-| `subnet_4o6_interface`         |       | String         |         |             |                                               |
-| `subnet_4o6_interface_id`      |       | String         |         |             |                                               |
-| `subnet_4o6_subnet`            |       | String         |         |             |                                               |
-| `authoritative`                |       | true, false    |         |             |                                               |
-| `boot_file_name`               |       | String         |         |             |                                               |
-| `cache_threshold`              |       | Integer        |         |             |                                               |
-| `cache_max_age`                |       | Integer        |         |             |                                               |
-| `calculate_tee_times`          |       | true, false    |         |             |                                               |
-| `client_class`                 |       | String         |         |             |                                               |
-| `ddns_generated_prefix`        |       | String         |         |             |                                               |
-| `ddns_override_client_update`  |       | true, false    |         |             |                                               |
-| `ddns_override_no_update`      |       | true, false    |         |             |                                               |
-| `ddns_replace_client_name`     |       | String, Symbol |         |             | never, always, when-present, when-not-present |
-| `ddns_qualifying_suffix`       |       | String         |         |             |                                               |
-| `ddns_send_updates`            |       | true, false    |         |             |                                               |
-| `ddns_update_on_renew`         |       | true, false    |         |             |                                               |
-| `ddns_use_conflict_resolution` |       | true, false    |         |             |                                               |
-| `hostname_char_set`            |       | String         |         |             |                                               |
-| `hostname_char_replacement`    |       | String         |         |             |                                               |
-| `interface`                    |       | String         |         |             |                                               |
-| `match_client_id`              |       | true, false    |         |             |                                               |
-| `min_valid_lifetime`           |       | Integer        |         |             |                                               |
-| `max_valid_lifetime`           |       | Integer        |         |             |                                               |
-| `next_server`                  |       | String         |         |             |                                               |
-| `rebind_timer`                 |       | Integer        |         |             |                                               |
-| `renew_timer`                  |       | Integer        |         |             |                                               |
-| `server_hostname`              |       | String         |         |             |                                               |
-| `valid_lifetime`               |       | String         |         |             |                                               |
-| `relay`                        |       | Hash           |         |             |                                               |
-| `require_client_classes`       |       | Array          |         |             |                                               |
-| `reservations_global`          |       | true, false    |         |             |                                               |
-| `reservations_in_subnet`       |       | true, false    |         |             |                                               |
-| `reservations_out_of_pool`     |       | true, false    |         |             |                                               |
-| `server_hostname`              |       | String         |         |             |                                               |
-| `store_extended_info`          |       | true, false    |         |             |                                               |
-| `t1_percent`                   |       | Integer, Float |         |             |                                               |
-| `t2_percent`                   |       | Integer, Float |         |             |                                               |
-| `valid_lifetime`               |       | Integer        |         |             |                                               |
-| `offer_lifetime`               |       | Integer        |         |             |                                               |
+| Name                           | Name? | Type                   | Default | Description | Allowed Values                                |
+| ------------------------------ | ----- | ---------------------- | ------- | ----------- | --------------------------------------------- |
+| `subnet_4o6_interface`         |       | String                 |         |             |                                               |
+| `subnet_4o6_interface_id`      |       | String                 |         |             |                                               |
+| `subnet_4o6_subnet`            |       | String                 |         |             |                                               |
+| `authoritative`                |       | true, false            |         |             |                                               |
+| `boot_file_name`               |       | String                 |         |             |                                               |
+| `cache_threshold`              |       | Integer                |         |             |                                               |
+| `cache_max_age`                |       | Integer                |         |             |                                               |
+| `calculate_tee_times`          |       | true, false            |         |             |                                               |
+| `client_class`                 |       | String                 |         |             |                                               |
+| `ddns_generated_prefix`        |       | String                 |         |             |                                               |
+| `ddns_override_client_update`  |       | true, false            |         |             |                                               |
+| `ddns_override_no_update`      |       | true, false            |         |             |                                               |
+| `ddns_replace_client_name`     |       | String, Symbol         |         |             | never, always, when-present, when-not-present |
+| `ddns_qualifying_suffix`       |       | String                 |         |             |                                               |
+| `ddns_send_updates`            |       | true, false            |         |             |                                               |
+| `ddns_ttl_percent`             |       | Float, Integer, String |         |             |                                               |
+| `ddns_update_on_renew`         |       | true, false            |         |             |                                               |
+| `ddns_use_conflict_resolution` |       | true, false            |         |             |                                               |
+| `hostname_char_set`            |       | String                 |         |             |                                               |
+| `hostname_char_replacement`    |       | String                 |         |             |                                               |
+| `interface`                    |       | String                 |         |             |                                               |
+| `match_client_id`              |       | true, false            |         |             |                                               |
+| `min_valid_lifetime`           |       | Integer                |         |             |                                               |
+| `max_valid_lifetime`           |       | Integer                |         |             |                                               |
+| `next_server`                  |       | String                 |         |             |                                               |
+| `rebind_timer`                 |       | Integer                |         |             |                                               |
+| `renew_timer`                  |       | Integer                |         |             |                                               |
+| `server_hostname`              |       | String                 |         |             |                                               |
+| `valid_lifetime`               |       | String                 |         |             |                                               |
+| `relay`                        |       | Hash                   |         |             |                                               |
+| `require_client_classes`       |       | Array                  |         |             |                                               |
+| `reservations_global`          |       | true, false            |         |             |                                               |
+| `reservations_in_subnet`       |       | true, false            |         |             |                                               |
+| `reservations_out_of_pool`     |       | true, false            |         |             |                                               |
+| `server_hostname`              |       | String                 |         |             |                                               |
+| `store_extended_info`          |       | true, false            |         |             |                                               |
+| `t1_percent`                   |       | Integer, Float         |         |             |                                               |
+| `t2_percent`                   |       | Integer, Float         |         |             |                                               |
+| `valid_lifetime`               |       | Integer                |         |             |                                               |
+| `offer_lifetime`               |       | Integer                |         |             |                                               |

--- a/documentation/partial/isc_kea__config_dhcp6_parameters_shared_network.md
+++ b/documentation/partial/isc_kea__config_dhcp6_parameters_shared_network.md
@@ -8,39 +8,40 @@
 
 ## Properties
 
-| Name                           | Name? | Type           | Default | Description | Allowed Values                                |
-| ------------------------------ | ----- | -------------- | ------- | ----------- | --------------------------------------------- |
-| `cache_threshold`              |       | Integer, Float |         |             |                                               |
-| `cache_max_age`                |       | Integer, Float |         |             |                                               |
-| `calculate_tee_times`          |       | true, false    |         |             |                                               |
-| `client_class`                 |       | String         |         |             |                                               |
-| `ddns_generated_prefix`        |       | String         |         |             |                                               |
-| `ddns_override_client_update`  |       | true, false    |         |             |                                               |
-| `ddns_override_no_update`      |       | true, false    |         |             |                                               |
-| `ddns_replace_client_name`     |       | String, Symbol |         |             | never, always, when-present, when-not-present |
-| `ddns_qualifying_suffix`       |       | String         |         |             |                                               |
-| `ddns_send_updates`            |       | true, false    |         |             |                                               |
-| `ddns_update_on_renew`         |       | true, false    |         |             |                                               |
-| `ddns_use_conflict_resolution` |       | true, false    |         |             |                                               |
-| `hostname_char_replacement`    |       | String         |         |             |                                               |
-| `hostname_char_set`            |       | String         |         |             |                                               |
-| `interface`                    |       | String         |         |             |                                               |
-| `interface_id`                 |       | String         |         |             |                                               |
-| `min_preferred_lifetime`       |       | Integer        |         |             |                                               |
-| `min_valid_lifetime`           |       | Integer        |         |             |                                               |
-| `max_preferred_lifetime`       |       | Integer        |         |             |                                               |
-| `max_valid_lifetime`           |       | Integer        |         |             |                                               |
-| `option_data`                  |       | Array          |         |             |                                               |
-| `preferred_lifetime`           |       | Integer        |         |             |                                               |
-| `rapid_commit`                 |       | true, false    |         |             |                                               |
-| `rebind_timer`                 |       | Integer        |         |             |                                               |
-| `relay`                        |       | Hash           |         |             |                                               |
-| `renew_timer`                  |       | String         |         |             |                                               |
-| `reservations_global`          |       | true, false    |         |             |                                               |
-| `reservations_in_subnet`       |       | true, false    |         |             |                                               |
-| `reservations_out_of_pool`     |       | true, false    |         |             |                                               |
-| `require_client_classes`       |       | Array          |         |             |                                               |
-| `store_extended_info`          |       | true, false    |         |             |                                               |
-| `t1_percent`                   |       | Integer, Float |         |             |                                               |
-| `t2_percent`                   |       | Integer, Float |         |             |                                               |
-| `valid_lifetime`               |       | Integer        |         |             |                                               |
+| Name                           | Name? | Type                   | Default | Description | Allowed Values                                |
+| ------------------------------ | ----- | ---------------------- | ------- | ----------- | --------------------------------------------- |
+| `cache_threshold`              |       | Integer, Float         |         |             |                                               |
+| `cache_max_age`                |       | Integer, Float         |         |             |                                               |
+| `calculate_tee_times`          |       | true, false            |         |             |                                               |
+| `client_class`                 |       | String                 |         |             |                                               |
+| `ddns_generated_prefix`        |       | String                 |         |             |                                               |
+| `ddns_override_client_update`  |       | true, false            |         |             |                                               |
+| `ddns_override_no_update`      |       | true, false            |         |             |                                               |
+| `ddns_replace_client_name`     |       | String, Symbol         |         |             | never, always, when-present, when-not-present |
+| `ddns_qualifying_suffix`       |       | String                 |         |             |                                               |
+| `ddns_send_updates`            |       | true, false            |         |             |                                               |
+| `ddns_ttl_percent`             |       | Float, Integer, String |         |             |                                               |
+| `ddns_update_on_renew`         |       | true, false            |         |             |                                               |
+| `ddns_use_conflict_resolution` |       | true, false            |         |             |                                               |
+| `hostname_char_replacement`    |       | String                 |         |             |                                               |
+| `hostname_char_set`            |       | String                 |         |             |                                               |
+| `interface`                    |       | String                 |         |             |                                               |
+| `interface_id`                 |       | String                 |         |             |                                               |
+| `min_preferred_lifetime`       |       | Integer                |         |             |                                               |
+| `min_valid_lifetime`           |       | Integer                |         |             |                                               |
+| `max_preferred_lifetime`       |       | Integer                |         |             |                                               |
+| `max_valid_lifetime`           |       | Integer                |         |             |                                               |
+| `option_data`                  |       | Array                  |         |             |                                               |
+| `preferred_lifetime`           |       | Integer                |         |             |                                               |
+| `rapid_commit`                 |       | true, false            |         |             |                                               |
+| `rebind_timer`                 |       | Integer                |         |             |                                               |
+| `relay`                        |       | Hash                   |         |             |                                               |
+| `renew_timer`                  |       | String                 |         |             |                                               |
+| `reservations_global`          |       | true, false            |         |             |                                               |
+| `reservations_in_subnet`       |       | true, false            |         |             |                                               |
+| `reservations_out_of_pool`     |       | true, false            |         |             |                                               |
+| `require_client_classes`       |       | Array                  |         |             |                                               |
+| `store_extended_info`          |       | true, false            |         |             |                                               |
+| `t1_percent`                   |       | Integer, Float         |         |             |                                               |
+| `t2_percent`                   |       | Integer, Float         |         |             |                                               |
+| `valid_lifetime`               |       | Integer                |         |             |                                               |

--- a/documentation/partial/isc_kea__config_dhcp6_parameters_subnet.md
+++ b/documentation/partial/isc_kea__config_dhcp6_parameters_subnet.md
@@ -8,37 +8,38 @@
 
 ## Properties
 
-| Name                           | Name? | Type           | Default | Description | Allowed Values                                |
-| ------------------------------ | ----- | -------------- | ------- | ----------- | --------------------------------------------- |
-| `cache_threshold`              |       | Integer, Float |         |             |                                               |
-| `cache_max_age`                |       | Integer, Float |         |             |                                               |
-| `client_class`                 |       | String         |         |             |                                               |
-| `ddns_generated_prefix`        |       | String         |         |             |                                               |
-| `ddns_override_client_update`  |       | true, false    |         |             |                                               |
-| `ddns_override_no_update`      |       | true, false    |         |             |                                               |
-| `ddns_replace_client_name`     |       | String, Symbol |         |             | never, always, when-present, when-not-present |
-| `ddns_qualifying_suffix`       |       | String         |         |             |                                               |
-| `ddns_send_updates`            |       | true, false    |         |             |                                               |
-| `ddns_update_on_renew`         |       | true, false    |         |             |                                               |
-| `ddns_use_conflict_resolution` |       | true, false    |         |             |                                               |
-| `hostname_char_replacement`    |       | String         |         |             |                                               |
-| `hostname_char_set`            |       | String         |         |             |                                               |
-| `interface`                    |       | String         |         |             |                                               |
-| `interface_id`                 |       | String         |         |             |                                               |
-| `min_preferred_lifetime`       |       | Integer        |         |             |                                               |
-| `min_valid_lifetime`           |       | Integer        |         |             |                                               |
-| `max_preferred_lifetime`       |       | Integer        |         |             |                                               |
-| `max_valid_lifetime`           |       | Integer        |         |             |                                               |
-| `preferred_lifetime`           |       | Integer        |         |             |                                               |
-| `rapid_commit`                 |       | true, false    |         |             |                                               |
-| `rebind_timer`                 |       | Integer        |         |             |                                               |
-| `relay`                        |       | Hash           |         |             |                                               |
-| `renew_timer`                  |       | Integer        |         |             |                                               |
-| `require_client_classes`       |       | Array          |         |             |                                               |
-| `reservations_global`          |       | true, false    |         |             |                                               |
-| `reservations_in_subnet`       |       | true, false    |         |             |                                               |
-| `reservations_out_of_pool`     |       | true, false    |         |             |                                               |
-| `store_extended_info`          |       | true, false    |         |             |                                               |
-| `t1_percent`                   |       | Integer, Float |         |             |                                               |
-| `t2_percent`                   |       | Integer, Float |         |             |                                               |
-| `valid_lifetime`               |       | Integer        |         |             |                                               |
+| Name                           | Name? | Type                   | Default | Description | Allowed Values                                |
+| ------------------------------ | ----- | ---------------------- | ------- | ----------- | --------------------------------------------- |
+| `cache_threshold`              |       | Integer, Float         |         |             |                                               |
+| `cache_max_age`                |       | Integer, Float         |         |             |                                               |
+| `client_class`                 |       | String                 |         |             |                                               |
+| `ddns_generated_prefix`        |       | String                 |         |             |                                               |
+| `ddns_override_client_update`  |       | true, false            |         |             |                                               |
+| `ddns_override_no_update`      |       | true, false            |         |             |                                               |
+| `ddns_replace_client_name`     |       | String, Symbol         |         |             | never, always, when-present, when-not-present |
+| `ddns_qualifying_suffix`       |       | String                 |         |             |                                               |
+| `ddns_send_updates`            |       | true, false            |         |             |                                               |
+| `ddns_ttl_percent`             |       | Float, Integer, String |         |             |                                               |
+| `ddns_update_on_renew`         |       | true, false            |         |             |                                               |
+| `ddns_use_conflict_resolution` |       | true, false            |         |             |                                               |
+| `hostname_char_replacement`    |       | String                 |         |             |                                               |
+| `hostname_char_set`            |       | String                 |         |             |                                               |
+| `interface`                    |       | String                 |         |             |                                               |
+| `interface_id`                 |       | String                 |         |             |                                               |
+| `min_preferred_lifetime`       |       | Integer                |         |             |                                               |
+| `min_valid_lifetime`           |       | Integer                |         |             |                                               |
+| `max_preferred_lifetime`       |       | Integer                |         |             |                                               |
+| `max_valid_lifetime`           |       | Integer                |         |             |                                               |
+| `preferred_lifetime`           |       | Integer                |         |             |                                               |
+| `rapid_commit`                 |       | true, false            |         |             |                                               |
+| `rebind_timer`                 |       | Integer                |         |             |                                               |
+| `relay`                        |       | Hash                   |         |             |                                               |
+| `renew_timer`                  |       | Integer                |         |             |                                               |
+| `require_client_classes`       |       | Array                  |         |             |                                               |
+| `reservations_global`          |       | true, false            |         |             |                                               |
+| `reservations_in_subnet`       |       | true, false            |         |             |                                               |
+| `reservations_out_of_pool`     |       | true, false            |         |             |                                               |
+| `store_extended_info`          |       | true, false            |         |             |                                               |
+| `t1_percent`                   |       | Integer, Float         |         |             |                                               |
+| `t2_percent`                   |       | Integer, Float         |         |             |                                               |
+| `valid_lifetime`               |       | Integer                |         |             |                                               |

--- a/resources/config_dhcp6.rb
+++ b/resources/config_dhcp6.rb
@@ -51,6 +51,9 @@ property :ddns_qualifying_suffix, String
 
 property :ddns_send_updates, [true, false]
 
+property :ddns_ttl_percent, [Float, Integer, String],
+          coerce: proc { |p| p.to_f }
+
 property :ddns_update_on_renew, [true, false]
 
 property :ddns_use_conflict_resolution, [true, false]

--- a/resources/partial/_config_dhcp4_parameters_shared_network.rb
+++ b/resources/partial/_config_dhcp4_parameters_shared_network.rb
@@ -43,6 +43,9 @@ property :ddns_qualifying_suffix, String
 
 property :ddns_send_updates, [true, false]
 
+property :ddns_ttl_percent, [Float, Integer, String],
+          coerce: proc { |p| p.to_f }
+
 property :ddns_update_on_renew, [true, false]
 
 property :ddns_use_conflict_resolution, [true, false]

--- a/resources/partial/_config_dhcp4_parameters_subnet.rb
+++ b/resources/partial/_config_dhcp4_parameters_subnet.rb
@@ -52,6 +52,9 @@ property :ddns_qualifying_suffix, String
 
 property :ddns_send_updates, [true, false]
 
+property :ddns_ttl_percent, [Float, Integer, String],
+          coerce: proc { |p| p.to_f }
+
 property :ddns_update_on_renew, [true, false]
 
 property :ddns_use_conflict_resolution, [true, false]

--- a/resources/partial/_config_dhcp6_parameters_shared_network.rb
+++ b/resources/partial/_config_dhcp6_parameters_shared_network.rb
@@ -39,6 +39,9 @@ property :ddns_qualifying_suffix, String
 
 property :ddns_send_updates, [true, false]
 
+property :ddns_ttl_percent, [Float, Integer, String],
+          coerce: proc { |p| p.to_f }
+
 property :ddns_update_on_renew, [true, false]
 
 property :ddns_use_conflict_resolution, [true, false]

--- a/resources/partial/_config_dhcp6_parameters_subnet.rb
+++ b/resources/partial/_config_dhcp6_parameters_subnet.rb
@@ -40,6 +40,9 @@ property :ddns_qualifying_suffix, String
 
 property :ddns_send_updates, [true, false]
 
+property :ddns_ttl_percent, [Float, Integer, String],
+          coerce: proc { |p| p.to_f }
+
 property :ddns_update_on_renew, [true, false]
 
 property :ddns_use_conflict_resolution, [true, false]


### PR DESCRIPTION
# Description

- Add `ddns-ttl-percent` option to all places it can be used

## Issues Resolved

- n/a

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
