### PR TITLE
Add stash agent option to dhcp4 config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of isc_kea.
 
 ## Unreleased
 
+- Add `stash-agent-option` property to `config_dhcp4`
+
 ## 1.6.0 - *2024-07-09*
 
 - Add per-resource sorting for all array based configuration resources

--- a/resources/config_dhcp4.rb
+++ b/resources/config_dhcp4.rb
@@ -106,6 +106,8 @@ property :server_hostname, String
 
 property :server_tag, String
 
+property :stash_agent_option, [true, false]
+
 property :statistic_default_sample_count, Integer
 
 property :statistic_default_sample_age, Integer


### PR DESCRIPTION
# Description

Add stash agent option to dhcp4 config

## Issues Resolved

- n/a

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
