### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of isc_kea.
 
 ## Unreleased
 
+- resolved cookstyle error: resources/config_dhcp4_subnet_pool_option_data.rb:57:11 refactor: `Chef/RedundantCode/UnnecessaryDesiredState`
+- resolved cookstyle error: resources/config_dhcp6_subnet_pool_option_data.rb:57:11 refactor: `Chef/RedundantCode/UnnecessaryDesiredState`
 ## 1.7.1 - *2024-12-18*
 
 - Correct property attributes for `config_match` used properties

--- a/resources/config_dhcp4_subnet_pool_option_data.rb
+++ b/resources/config_dhcp4_subnet_pool_option_data.rb
@@ -53,8 +53,7 @@ property :option_name, String,
           name_property: true
 
 property :code, Integer,
-          identity: true,
-          desired_state: true
+          identity: true
 
 property :space, String
 

--- a/resources/config_dhcp6_subnet_pool_option_data.rb
+++ b/resources/config_dhcp6_subnet_pool_option_data.rb
@@ -53,8 +53,7 @@ property :option_name, String,
           name_property: true
 
 property :code, Integer,
-          identity: true,
-          desired_state: true
+          identity: true
 
 property :space, String
 


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.32.8 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with resources/config_dhcp4_subnet_pool_option_data.rb

 - 57:11 refactor: `Chef/RedundantCode/UnnecessaryDesiredState` - There is no need to set a property to desired_state: true as all properties have a desired_state of true by default. (https://docs.chef.io/workstation/cookstyle/chef_redundantcode_unnecessarydesiredstate)

### Issues found and resolved with resources/config_dhcp6_subnet_pool_option_data.rb

 - 57:11 refactor: `Chef/RedundantCode/UnnecessaryDesiredState` - There is no need to set a property to desired_state: true as all properties have a desired_state of true by default. (https://docs.chef.io/workstation/cookstyle/chef_redundantcode_unnecessarydesiredstate)